### PR TITLE
Fix issue #13: "There's a problem with this sticker pack" on Android

### DIFF
--- a/android/src/main/kotlin/dev/applicazza/flutter/plugins/whatsapp_stickers/StickerContentProvider.java
+++ b/android/src/main/kotlin/dev/applicazza/flutter/plugins/whatsapp_stickers/StickerContentProvider.java
@@ -9,7 +9,6 @@
 package dev.applicazza.flutter.plugins.whatsapp_stickers;
 
 import android.content.ContentProvider;
-import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.UriMatcher;
@@ -18,6 +17,7 @@ import android.content.res.AssetManager;
 import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.net.Uri;
+import android.os.Bundle;
 import android.os.ParcelFileDescriptor;
 import android.text.TextUtils;
 import android.util.Log;
@@ -75,6 +75,8 @@ public class StickerContentProvider extends ContentProvider {
     private static final int STICKERS_ASSET_CODE = 4;
 
     private static final int STICKER_PACK_TRAY_ICON_CODE = 5;
+
+    public static final String REFRESH = "refresh";
 
     private List<StickerPack> stickerPackList;
 
@@ -313,5 +315,15 @@ public class StickerContentProvider extends ContentProvider {
     public int update(@NonNull Uri uri, ContentValues values, String selection,
                       String[] selectionArgs) {
         throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Nullable
+    @Override
+    public Bundle call(@NonNull String method, @Nullable String arg, @Nullable Bundle extras) {
+        if (method.equals(REFRESH)) {
+            readContentFile(Objects.requireNonNull(getContext()));
+            return null;
+        }
+        return super.call(method, arg, extras);
     }
 }

--- a/android/src/main/kotlin/dev/applicazza/flutter/plugins/whatsapp_stickers/WhatsappStickersPlugin.kt
+++ b/android/src/main/kotlin/dev/applicazza/flutter/plugins/whatsapp_stickers/WhatsappStickersPlugin.kt
@@ -140,11 +140,11 @@ public class WhatsappStickersPlugin: FlutterPlugin, MethodCallHandler, ActivityA
   }
 
   override fun onDetachedFromActivity() {
-    TODO("Not yet implemented")
+    // TODO: Not yet implemented
   }
 
   override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-    TODO("Not yet implemented")
+    // TODO: Not yet implemented
   }
 
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
@@ -152,7 +152,7 @@ public class WhatsappStickersPlugin: FlutterPlugin, MethodCallHandler, ActivityA
   }
 
   override fun onDetachedFromActivityForConfigChanges() {
-    TODO("Not yet implemented")
+    // TODO: Not yet implemented
   }
 
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {

--- a/android/src/main/kotlin/dev/applicazza/flutter/plugins/whatsapp_stickers/WhatsappStickersPlugin.kt
+++ b/android/src/main/kotlin/dev/applicazza/flutter/plugins/whatsapp_stickers/WhatsappStickersPlugin.kt
@@ -6,7 +6,6 @@ import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import androidx.annotation.NonNull
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -17,7 +16,6 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
 import io.flutter.plugin.common.PluginRegistry.Registrar
-import java.io.File
 
 
 /** WhatsappStickersPlugin */
@@ -73,7 +71,11 @@ public class WhatsappStickersPlugin: FlutterPlugin, MethodCallHandler, ActivityA
     fun getContentProviderAuthority(context: Context): String {
       return context.packageName + ".stickercontentprovider"
     }
-    
+
+    @JvmStatic
+    fun refreshContentProvider(context: Context) {
+      context.contentResolver?.call(getContentProviderAuthorityURI(context), StickerContentProvider.REFRESH, null, null)
+    }
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -99,6 +101,7 @@ public class WhatsappStickersPlugin: FlutterPlugin, MethodCallHandler, ActivityA
           val stickerPack: StickerPack = ConfigFileManager.fromMethodCall(context, call)
           // update json file
           ConfigFileManager.addNewPack(context, stickerPack)
+          context?.let { refreshContentProvider(it) }
           context?.let { StickerPackValidator.verifyStickerPackValidity(it, stickerPack) };
           // send intent to whatsapp
           val ws = WhitelistCheck.isWhatsAppConsumerAppInstalled(context?.packageManager)
@@ -109,7 +112,6 @@ public class WhatsappStickersPlugin: FlutterPlugin, MethodCallHandler, ActivityA
           val stickerPackIdentifier = stickerPack.identifier
           val stickerPackName = stickerPack.name
           val authority: String? = context?.let { getContentProviderAuthority(it) }
-
           val intent = createIntentToAddStickerPack(authority, stickerPackIdentifier, stickerPackName)
 
           try {


### PR DESCRIPTION
#13 
The StickerContentProvider caches the list of stickerPacks in memory after the first query. So, it does not know about new stickers added in the current application session. It only knows about stickerPacks already installed in WA or those that failed to install in previous application sessions.

Steps to reproduce:
1. Delete your app to cleanup app data (sticker_packs.json)
2. Install your app
3. Try to install first stickerPack - this will be successful.
4. Try to install other stickerPacks - they'll all fail.
5. Relaunch your app and try to install again - all stickerPacks, failed in previous app session will be intalled successfully.

I have added a method that notifies StickerContentProvider to reload stickerPack's list from file.